### PR TITLE
Improve initial player state if autoplay=false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webfactoryde/video-utils",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Web Component with progressive enhancements for the HTML <video> element",
   "main": "src/video-utils.js",
   "repository": {

--- a/src/video-utils.js
+++ b/src/video-utils.js
@@ -43,14 +43,15 @@ class VideoUtils extends HTMLElement {
 
         // adhere to users' motion preferences
         this.motionQuery = matchMedia('(prefers-reduced-motion: reduce)');
-        this.handleReducedMotion();
-        this.motionQuery.addEventListener('change', this.handleReducedMotion.bind(this));
+        this.motionQuery.addEventListener('change', this.updatePlayerState.bind(this));
+
+        this.updatePlayerState();
 
         this.initialized = true;
     }
 
-    handleReducedMotion() {
-        if (this.motionQuery.matches) {
+    updatePlayerState() {
+        if (this.motionQuery.matches || !this.video.autoplay) {
             this._pause();
         } else if (this.video.autoplay) {
             this._play();


### PR DESCRIPTION
This PR fixes a bug in the condition that resulted in both play and pause buttons being visible on load if `autoplay="false"`. The method has been renamed to `updatePlayerState` to clarify its more general purpose.